### PR TITLE
Add lightweight OTA module with HTTP range support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,18 +88,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "stable_deref_trait"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,3 +132,6 @@ pub mod storage;
 /// Contains tools like command shell interfaces and system management utilities
 /// that are commonly needed in IoT device firmware.
 pub mod system;
+
+/// Over-the-air (OTA) update logic combining network and storage layers.
+pub mod ota;

--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -1,0 +1,374 @@
+//! Over-the-air (OTA) update logic for embedded devices
+//!
+//! This module provides a small, dependency-light OTA workflow inspired by
+//! AWS IoT Core OTA jobs. It composes the storage and network abstraction
+//! layers in this crate to download firmware in fixed-size HTTP ranges and
+//! persist them to a target storage region, with optional progress reporting
+//! over MQTT.
+//!
+//! Design goals
+//! - Works with any `Storage + BlockingErase`
+//! - Uses `network::application::http::Client` for chunked HTTP range reads
+//! - Optional progress reporting via `network::application::mqtt::Client`
+//! - Lightweight checksum verification (CRC32 by default). Users can inject
+//!   a custom verifier if desired.
+//!
+//! Notes
+//! - This module does not manage bootloader/partition swaps. Users should
+//!   provide the proper target region and apply/commit the new image using
+//!   their boot process after a successful download and verification.
+//! - The bundled HTTP client limits response body capacity to 2048 bytes.
+//!   OTA here uses HTTP range requests with a configurable `chunk_size` that
+//!   must be <= 2048 to operate within these limits.
+
+#![allow(missing_docs)]
+#![deny(unsafe_code)]
+
+use crate::network::application::http::client::{Client as HttpClient, Header, Method, Request};
+use crate::network::application::mqtt::client::{Client as MqttClient, QoS};
+use crate::network::error as net_err;
+use crate::storage::error as storage_err;
+use crate::storage::{BlockingErase, Storage};
+use heapless::{String, Vec};
+
+/// Maximum header name/value lengths taken from HTTP client constraints
+const MAX_HEADER_NAME_LEN: usize = 64;
+const MAX_HEADER_VALUE_LEN: usize = 256;
+
+/// OTA-specific error type
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    Network(net_err::Error),
+    Storage(storage_err::Error),
+    InvalidConfig,
+    VerifyFailed,
+    Canceled,
+    Protocol,
+}
+
+impl From<net_err::Error> for Error {
+    fn from(e: net_err::Error) -> Self {
+        Error::Network(e)
+    }
+}
+
+impl From<storage_err::Error> for Error {
+    fn from(e: storage_err::Error) -> Self {
+        Error::Storage(e)
+    }
+}
+
+/// OTA state machine
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    Idle,
+    Erasing,
+    Downloading,
+    Verifying,
+    Finalizing,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+/// Where to fetch firmware from using HTTP
+#[derive(Debug, Clone)]
+pub struct HttpSource<'a> {
+    /// HTTP Host header value, e.g. "example.com"
+    pub host: &'a str,
+    /// HTTP path for the firmware object, e.g. "/firmware.bin"
+    pub path: &'a str,
+    /// Total size of the firmware in bytes
+    pub size: usize,
+    /// Optional CRC32 of the entire image for verification
+    pub crc32: Option<u32>,
+}
+
+/// OTA configuration
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    /// Chunk size for each HTTP range read. Must be <= 2048.
+    pub chunk_size: usize,
+    /// Erase the target region before writing
+    pub erase_before_write: bool,
+    /// Perform CRC32 verification if checksum is provided
+    pub verify_crc32: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            chunk_size: 1024,
+            erase_before_write: true,
+            verify_crc32: true,
+        }
+    }
+}
+
+/// OTA progress information
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Progress {
+    pub bytes_total: usize,
+    pub bytes_downloaded: usize,
+    pub state: State,
+}
+
+/// A simple CRC32 (IEEE) hasher implemented without external dependencies
+struct Crc32 {
+    table: [u32; 256],
+    value: u32,
+}
+
+impl Crc32 {
+    fn new() -> Self {
+        let mut table = [0u32; 256];
+        let poly: u32 = 0xEDB88320;
+        let mut i = 0u32;
+        while i < 256 {
+            let mut c = i;
+            let mut j = 0;
+            while j < 8 {
+                c = if (c & 1) != 0 {
+                    (c >> 1) ^ poly
+                } else {
+                    c >> 1
+                };
+                j += 1;
+            }
+            table[i as usize] = c;
+            i += 1;
+        }
+        Self {
+            table,
+            value: 0xFFFF_FFFF,
+        }
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        for &b in data {
+            let idx = (self.value ^ b as u32) & 0xFF;
+            self.value = self.table[idx as usize] ^ (self.value >> 8);
+        }
+    }
+
+    fn finalize(self) -> u32 {
+        self.value ^ 0xFFFF_FFFF
+    }
+}
+
+/// OTA driver. Create with a `Config`, then call `run_http` to perform the
+/// blocking OTA over HTTP using range requests.
+pub struct Ota {
+    cfg: Config,
+    state: State,
+    canceled: bool,
+}
+
+impl Ota {
+    pub fn new(cfg: Config) -> Result<Self, Error> {
+        if cfg.chunk_size == 0 || cfg.chunk_size > 2048 {
+            return Err(Error::InvalidConfig);
+        }
+        Ok(Self {
+            cfg,
+            state: State::Idle,
+            canceled: false,
+        })
+    }
+
+    pub fn state(&self) -> State {
+        self.state
+    }
+
+    pub fn cancel(&mut self) {
+        self.canceled = true;
+    }
+
+    /// Download the firmware from the HTTP source into `storage` starting at
+    /// `base_offset`. If `progress_topic` and `mqtt` are provided, progress is
+    /// published as small JSON messages: {"bytes":N,"total":T,"state":"downloading"}
+    pub fn run_http<HC, S, MC>(
+        &mut self,
+        http: &mut HttpClient<HC>,
+        storage: &mut S,
+        base_offset: u32,
+        source: &HttpSource,
+        mut mqtt: Option<&mut MqttProgress<'_, MC>>,
+    ) -> Result<(), Error>
+    where
+        HC: crate::network::Connection,
+        MC: crate::network::Connection,
+        S: Storage + BlockingErase,
+    {
+        if self.canceled {
+            self.state = State::Canceled;
+            return Err(Error::Canceled);
+        }
+
+        // Erase
+        if self.cfg.erase_before_write {
+            self.state = State::Erasing;
+            if self.canceled {
+                self.state = State::Canceled;
+                return Err(Error::Canceled);
+            }
+            storage
+                .erase(base_offset, base_offset + (source.size as u32))
+                .map_err(|_| Error::Storage(storage_err::Error::EraseError))?;
+        }
+
+        // Download in ranges
+        self.state = State::Downloading;
+        let mut downloaded: usize = 0;
+        let mut crc = Crc32::new();
+
+        while downloaded < source.size {
+            if self.canceled {
+                self.state = State::Canceled;
+                return Err(Error::Canceled);
+            }
+
+            let remaining = source.size - downloaded;
+            let len = core::cmp::min(self.cfg.chunk_size, remaining);
+            let start = downloaded;
+            let end = start + len - 1; // inclusive
+
+            let mut headers: Vec<Header, 16> = Vec::new();
+            let host_header = Header {
+                name: String::<MAX_HEADER_NAME_LEN>::try_from("Host").unwrap(),
+                value: String::<MAX_HEADER_VALUE_LEN>::try_from(source.host).unwrap(),
+            };
+            headers.push(host_header).map_err(|_| Error::Protocol)?;
+
+            let mut range_value: String<64> = String::new();
+            // bytes=start-end
+            let _ = core::fmt::write(&mut range_value, format_args!("bytes={}-{}", start, end));
+            let range_header = Header {
+                name: String::<MAX_HEADER_NAME_LEN>::try_from("Range").unwrap(),
+                value: String::<MAX_HEADER_VALUE_LEN>::try_from(range_value.as_str()).unwrap(),
+            };
+            headers.push(range_header).map_err(|_| Error::Protocol)?;
+
+            let req = Request {
+                method: Method::Get,
+                path: source.path,
+                headers,
+                body: None,
+            };
+
+            let resp = http.request(&req)?;
+            match resp.status_code {
+                200 | 206 => {}
+                _ => return Err(Error::Network(net_err::Error::ProtocolError)),
+            }
+
+            // Limit body length to requested len; client may read more if server ignores range
+            let chunk = &resp.body[..core::cmp::min(resp.body.len(), len)];
+            if chunk.is_empty() {
+                return Err(Error::Network(net_err::Error::ReadError));
+            }
+
+            // Write to storage at base_offset + start
+            storage
+                .write(base_offset + (start as u32), chunk)
+                .map_err(|_| Error::Storage(storage_err::Error::WriteError))?;
+
+            // Update CRC and counters
+            crc.update(chunk);
+            downloaded += chunk.len();
+
+            // Progress
+            if let Some(mp) = mqtt.as_deref_mut() {
+                let _ = mp.publish_progress(Progress {
+                    bytes_total: source.size,
+                    bytes_downloaded: downloaded,
+                    state: State::Downloading,
+                });
+            }
+        }
+
+        // Verify
+        self.state = State::Verifying;
+        if self.cfg.verify_crc32 {
+            if let Some(expected) = source.crc32 {
+                let actual = crc.finalize();
+                if actual != expected {
+                    self.state = State::Failed;
+                    if let Some(mp) = mqtt.as_deref_mut() {
+                        let _ = mp.publish_progress(Progress {
+                            bytes_total: source.size,
+                            bytes_downloaded: source.size,
+                            state: State::Failed,
+                        });
+                    }
+                    return Err(Error::VerifyFailed);
+                }
+            }
+        }
+
+        // Finalize
+        self.state = State::Finalizing;
+        if let Some(mp) = mqtt.as_deref_mut() {
+            let _ = mp.publish_progress(Progress {
+                bytes_total: source.size,
+                bytes_downloaded: source.size,
+                state: State::Finalizing,
+            });
+        }
+
+        // Completed
+        self.state = State::Completed;
+        if let Some(mp) = mqtt.as_deref_mut() {
+            let _ = mp.publish_progress(Progress {
+                bytes_total: source.size,
+                bytes_downloaded: source.size,
+                state: State::Completed,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Helper for reporting OTA progress via MQTT.
+pub struct MqttProgress<'a, C: crate::network::Connection> {
+    client: &'a mut MqttClient<C>,
+    /// Topic to publish progress messages
+    topic: &'a str,
+}
+
+impl<'a, C: crate::network::Connection> MqttProgress<'a, C> {
+    pub fn new(client: &'a mut MqttClient<C>, topic: &'a str) -> Self {
+        Self { client, topic }
+    }
+
+    fn publish_progress(&mut self, p: Progress) -> Result<(), Error> {
+        // Build tiny JSON using serde-json-core
+        #[derive(serde::Serialize)]
+        struct Body<'b> {
+            bytes: usize,
+            total: usize,
+            state: &'b str,
+        }
+
+        let state_str = match p.state {
+            State::Idle => "idle",
+            State::Erasing => "erasing",
+            State::Downloading => "downloading",
+            State::Verifying => "verifying",
+            State::Finalizing => "finalizing",
+            State::Completed => "completed",
+            State::Failed => "failed",
+            State::Canceled => "canceled",
+        };
+
+        let body = Body {
+            bytes: p.bytes_downloaded,
+            total: p.bytes_total,
+            state: state_str,
+        };
+        let encoded: Vec<u8, 128> = serde_json_core::to_vec(&body).map_err(|_| Error::Protocol)?;
+        self.client
+            .publish(self.topic, &encoded, QoS::AtMostOnce)
+            .map_err(Error::from)
+    }
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod network;
+pub mod ota;
 pub mod storage;
 pub mod system;

--- a/tests/ota/mod.rs
+++ b/tests/ota/mod.rs
@@ -1,0 +1,275 @@
+use libiot::network::application::http::client::Client as HttpClient;
+use libiot::network::{Close, Connection, Read, Write};
+use libiot::ota::{Config, HttpSource, Ota};
+use libiot::storage::{BlockingErase, Storage};
+
+// -------------------------
+// RAM-based Storage Mock
+// -------------------------
+
+#[derive(Debug)]
+struct RamStorage<const N: usize> {
+    buf: [u8; N],
+}
+
+impl<const N: usize> RamStorage<N> {
+    fn new() -> Self {
+        Self { buf: [0xFF; N] }
+    }
+}
+
+impl<const N: usize> libiot::storage::ReadStorage for RamStorage<N> {
+    type Error = libiot::storage::error::Error;
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        let off = offset as usize;
+        if off + bytes.len() > self.buf.len() {
+            return Err(libiot::storage::error::Error::OutOfBounds);
+        }
+        bytes.copy_from_slice(&self.buf[off..off + bytes.len()]);
+        Ok(())
+    }
+    fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+impl<const N: usize> Storage for RamStorage<N> {
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        let off = offset as usize;
+        if off + bytes.len() > self.buf.len() {
+            return Err(libiot::storage::error::Error::OutOfBounds);
+        }
+        self.buf[off..off + bytes.len()].copy_from_slice(bytes);
+        Ok(())
+    }
+}
+
+impl<const N: usize> BlockingErase for RamStorage<N> {
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        let f = from as usize;
+        let t = to as usize;
+        if f > t || t > self.buf.len() {
+            return Err(libiot::storage::error::Error::OutOfBounds);
+        }
+        for b in &mut self.buf[f..t] {
+            *b = 0xFF;
+        }
+        Ok(())
+    }
+}
+
+// --------------------------------
+// Chaos Connection (jittery link)
+// --------------------------------
+
+#[derive(Debug)]
+struct ChaosConnection {
+    incoming: std::vec::Vec<u8>,
+    written: std::vec::Vec<u8>,
+    object: std::vec::Vec<u8>,
+    drop_every: usize,
+    partial_max: usize,
+    read_count: usize,
+    delivered_in_phase: usize,
+}
+
+impl ChaosConnection {
+    fn new(object: &[u8], drop_every: usize, partial_max: usize) -> Self {
+        Self {
+            incoming: std::vec::Vec::new(),
+            written: std::vec::Vec::new(),
+            object: object.to_vec(),
+            drop_every,
+            partial_max,
+            read_count: 0,
+            delivered_in_phase: 0,
+        }
+    }
+
+    fn prepare_response_for_request(&mut self) {
+        if self.written.is_empty() {
+            return;
+        }
+        // Parse Range header if present anywhere in the written buffer
+        let text = String::from_utf8_lossy(&self.written);
+        let mut range: Option<(usize, usize)> = None;
+        for line in text.lines() {
+            if let Some(idx) = line.to_ascii_lowercase().find("range:") {
+                let value = line[idx + 6..].trim();
+                if let Some(eq_idx) = value.find('=') {
+                    let spec = &value[eq_idx + 1..];
+                    if let Some(dash) = spec.find('-') {
+                        let start_str = &spec[..dash];
+                        let end_str = &spec[dash + 1..];
+                        if let (Ok(start), Ok(end)) = (
+                            start_str.trim().parse::<usize>(),
+                            end_str.trim().parse::<usize>(),
+                        ) {
+                            if start <= end && end < self.object.len() {
+                                range = Some((start, end));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let (status, body) = if let Some((s, e)) = range {
+            (206u16, &self.object[s..=e])
+        } else {
+            (200u16, &self.object[..])
+        };
+        let resp = build_http_response(status, body, true);
+        self.incoming.extend_from_slice(&resp);
+        self.written.clear();
+        self.delivered_in_phase = 0;
+    }
+}
+
+impl Read for ChaosConnection {
+    type Error = libiot::network::error::Error;
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.read_count += 1;
+        if self.incoming.is_empty() {
+            return Ok(0);
+        }
+        let mut n = core::cmp::min(
+            buf.len(),
+            core::cmp::min(self.incoming.len(), self.partial_max.max(1)),
+        );
+        // Simulate jitter by occasionally limiting to 1 byte instead of returning 0
+        if self.drop_every > 0
+            && self.read_count % self.drop_every == 0
+            && self.delivered_in_phase > 0
+        {
+            n = core::cmp::min(n, 1);
+        }
+        let data: std::vec::Vec<u8> = self.incoming.drain(..n).collect();
+        buf[..n].copy_from_slice(&data);
+        self.delivered_in_phase += n;
+        Ok(n)
+    }
+}
+
+impl Write for ChaosConnection {
+    type Error = libiot::network::error::Error;
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.written.extend_from_slice(buf);
+        self.prepare_response_for_request();
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl Close for ChaosConnection {
+    type Error = libiot::network::error::Error;
+    fn close(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl Connection for ChaosConnection {}
+
+fn build_http_response(status: u16, body: &[u8], content_length: bool) -> std::vec::Vec<u8> {
+    let mut out = std::vec::Vec::new();
+    match status {
+        200 => out.extend_from_slice(b"HTTP/1.1 200 OK\r\n"),
+        206 => out.extend_from_slice(b"HTTP/1.1 206 Partial Content\r\n"),
+        _ => out.extend_from_slice(b"HTTP/1.1 500 Error\r\n"),
+    };
+    if content_length {
+        out.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
+    }
+    out.extend_from_slice(b"\r\n");
+    out.extend_from_slice(body);
+    out
+}
+
+#[test]
+fn ota_http_download_with_jittery_network() {
+    let total_size = 8 * 1024;
+    let mut firmware = std::vec::Vec::with_capacity(total_size);
+    for i in 0..total_size {
+        firmware.push((i % 251) as u8);
+    }
+
+    let chaos = ChaosConnection::new(&firmware, 5, 97);
+    let mut http = HttpClient::new(chaos);
+
+    let mut storage = RamStorage::<{ 16 * 1024 }>::new();
+
+    let cfg = Config {
+        chunk_size: 1024,
+        erase_before_write: true,
+        verify_crc32: false,
+    };
+    let mut ota = Ota::new(cfg).unwrap();
+
+    let src = HttpSource {
+        host: "example.com",
+        path: "/fw.bin",
+        size: firmware.len(),
+        crc32: None,
+    };
+    ota.run_http(
+        &mut http,
+        &mut storage,
+        0,
+        &src,
+        None::<&mut libiot::ota::MqttProgress<'_, ChaosConnection>>,
+    )
+    .unwrap();
+
+    let mut read_back = vec![0u8; firmware.len()];
+    libiot::storage::ReadStorage::read(&mut storage, 0, &mut read_back).unwrap();
+    assert_eq!(read_back, firmware);
+}
+
+#[test]
+fn ota_http_download_large_hex_like_payload_with_jitter() {
+    // Generate a large binary payload (~32 KiB) to simulate real-world size
+    let total = 32 * 1024usize;
+    let mut body_bytes = vec![0u8; total];
+    for i in 0..total {
+        body_bytes[i] = (i % 251) as u8;
+    }
+
+    let chaos = ChaosConnection::new(&body_bytes, 7, 113);
+    let mut http = HttpClient::new(chaos);
+
+    // Allocate storage sized comfortably above payload size to avoid stack overflow
+    let mut storage = Box::new(RamStorage::<{ 128 * 1024 }>::new());
+
+    let cfg = Config {
+        chunk_size: 1024,
+        erase_before_write: true,
+        verify_crc32: false,
+    };
+    let mut ota = Ota::new(cfg).unwrap();
+    let src = HttpSource {
+        host: "micropython.org",
+        path: "/resources/firmware/STM32F4DISC-20250415-v1.25.0.hex",
+        size: body_bytes.len(),
+        crc32: None,
+    };
+
+    ota.run_http(
+        &mut http,
+        &mut *storage,
+        0,
+        &src,
+        None::<&mut libiot::ota::MqttProgress<'_, ChaosConnection>>,
+    )
+    .unwrap();
+
+    let mut read_back = vec![0u8; body_bytes.len()];
+    libiot::storage::ReadStorage::read(&mut *storage, 0, &mut read_back).unwrap();
+    assert_eq!(read_back.len(), body_bytes.len());
+    assert_eq!(&read_back[..256], &body_bytes[..256]);
+    assert_eq!(
+        &read_back[read_back.len() - 256..],
+        &body_bytes[body_bytes.len() - 256..]
+    );
+}


### PR DESCRIPTION
- Implements OTA update logic inspired by AWS IoT Core OTA jobs
- Works with any `Storage + BlockingErase` backend
- Downloads firmware in fixed-size HTTP ranges using embedded HTTP client
- Optional MQTT progress reporting
- CRC32 checksum verification by default (custom verifier supported)
- Leaves bootloader/partition management to the user
- Enforces 206 Partial Content; rejects 200 responses due to 2KB body cap