### PR TITLE
Add GPS NMEA 0183 parser and tests

### DIFF
--- a/src/gps/mod.rs
+++ b/src/gps/mod.rs
@@ -1,0 +1,829 @@
+//! GPS NMEA 0183 sentence parser
+//!
+//! This module provides a lightweight NMEA parser for embedded systems,
+//! supporting common GPS sentence types like GPGGA, GPRMC, and GPGLL.
+
+/// Maximum length of an NMEA sentence including \r\n
+pub const NMEA_MAX_LENGTH: usize = 82;
+
+/// NMEA sentence prefix length (e.g., "GPGGA")
+pub const NMEA_PREFIX_LENGTH: usize = 5;
+
+/// NMEA sentence ending characters
+pub const NMEA_END_CHAR_1: u8 = b'\r';
+/// NMEA sentence ending characters
+pub const NMEA_END_CHAR_2: u8 = b'\n';
+
+/// NMEA sentence types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NmeaType {
+    /// Unknown sentence type
+    Unknown,
+    /// GPGGA - Global Positioning System Fix Data
+    Gpgga,
+    /// GPGLL - Geographic Position - Latitude/Longitude
+    Gpgll,
+    /// GPGSA - GPS DOP and active satellites
+    Gpgsa,
+    /// GPGSV - GPS Satellites in view
+    Gpgsv,
+    /// GPRMC - Recommended Minimum Course
+    Gprmc,
+    /// GPTXT - Text Transmission
+    Gptxt,
+    /// GPVTG - Track made good and Ground speed
+    Gpvtg,
+}
+
+/// Cardinal direction
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardinalDirection {
+    /// North
+    North,
+    /// East
+    East,
+    /// South
+    South,
+    /// West
+    West,
+    /// Unknown direction
+    Unknown,
+}
+
+impl CardinalDirection {
+    /// Parse cardinal direction from a character
+    pub fn from_char(c: char) -> Self {
+        match c {
+            'N' => CardinalDirection::North,
+            'E' => CardinalDirection::East,
+            'S' => CardinalDirection::South,
+            'W' => CardinalDirection::West,
+            _ => CardinalDirection::Unknown,
+        }
+    }
+
+    /// Convert to character representation
+    pub fn to_char(self) -> char {
+        match self {
+            CardinalDirection::North => 'N',
+            CardinalDirection::East => 'E',
+            CardinalDirection::South => 'S',
+            CardinalDirection::West => 'W',
+            CardinalDirection::Unknown => '\0',
+        }
+    }
+}
+
+/// GPS position (latitude or longitude)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Position {
+    /// Degrees component of the position
+    pub degrees: i32,
+    /// Minutes component of the position (decimal)
+    pub minutes: f64,
+    /// Cardinal direction (N/S for latitude, E/W for longitude)
+    pub cardinal: CardinalDirection,
+}
+
+impl Position {
+    /// Create a new position
+    pub fn new(degrees: i32, minutes: f64, cardinal: CardinalDirection) -> Self {
+        Self {
+            degrees,
+            minutes,
+            cardinal,
+        }
+    }
+
+    /// Convert to decimal degrees
+    pub fn to_decimal_degrees(&self) -> f64 {
+        let decimal = self.degrees as f64 + self.minutes / 60.0;
+        match self.cardinal {
+            CardinalDirection::South | CardinalDirection::West => -decimal,
+            _ => decimal,
+        }
+    }
+}
+
+impl Default for Position {
+    fn default() -> Self {
+        Self {
+            degrees: 0,
+            minutes: 0.0,
+            cardinal: CardinalDirection::Unknown,
+        }
+    }
+}
+
+/// Time structure for NMEA sentences
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NmeaTime {
+    /// Hour (0-23)
+    pub hour: u8,
+    /// Minute (0-59)
+    pub minute: u8,
+    /// Second (0-59)
+    pub second: u8,
+}
+
+impl Default for NmeaTime {
+    fn default() -> Self {
+        Self {
+            hour: 0,
+            minute: 0,
+            second: 0,
+        }
+    }
+}
+
+/// Date structure for NMEA sentences
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NmeaDate {
+    /// Day of month (1-31)
+    pub day: u8,
+    /// Month (1-12)
+    pub month: u8,
+    /// Year (4-digit)
+    pub year: u16,
+}
+
+impl Default for NmeaDate {
+    fn default() -> Self {
+        Self {
+            day: 1,
+            month: 1,
+            year: 2000,
+        }
+    }
+}
+
+/// Base NMEA sentence structure
+#[derive(Debug, Clone, PartialEq)]
+pub struct NmeaBase {
+    /// Type of NMEA sentence
+    pub sentence_type: NmeaType,
+    /// Number of parsing errors encountered
+    pub errors: u32,
+}
+
+/// GPGGA sentence - Global Positioning System Fix Data
+#[derive(Debug, Clone, PartialEq)]
+pub struct Gpgga {
+    /// Base sentence information
+    pub base: NmeaBase,
+    /// UTC time of position fix
+    pub time: NmeaTime,
+    /// Latitude position
+    pub latitude: Position,
+    /// Longitude position
+    pub longitude: Position,
+    /// Position fix indicator (0=invalid, 1=GPS fix, 2=DGPS fix)
+    pub position_fix: u8,
+    /// Number of satellites being tracked
+    pub satellites_used: u8,
+    /// Horizontal dilution of precision
+    pub hdop: f32,
+    /// Antenna altitude above/below mean-sea-level (geoid)
+    pub altitude: f32,
+    /// Units of antenna altitude (usually 'M' for meters)
+    pub altitude_unit: char,
+    /// Geoidal separation (difference between WGS-84 earth ellipsoid and mean-sea-level)
+    pub undulation: f32,
+    /// Units of geoidal separation (usually 'M' for meters)
+    pub undulation_unit: char,
+    /// Time in seconds since last DGPS update
+    pub dgps_age: Option<f32>,
+    /// DGPS station ID number
+    pub dgps_station_id: Option<u16>,
+}
+
+impl Default for Gpgga {
+    fn default() -> Self {
+        Self {
+            base: NmeaBase {
+                sentence_type: NmeaType::Gpgga,
+                errors: 0,
+            },
+            time: NmeaTime::default(),
+            latitude: Position::default(),
+            longitude: Position::default(),
+            position_fix: 0,
+            satellites_used: 0,
+            hdop: 0.0,
+            altitude: 0.0,
+            altitude_unit: 'M',
+            undulation: -9999.999,
+            undulation_unit: 'M',
+            dgps_age: None,
+            dgps_station_id: None,
+        }
+    }
+}
+
+/// GPRMC sentence - Recommended Minimum Course
+#[derive(Debug, Clone, PartialEq)]
+pub struct Gprmc {
+    /// Base sentence information
+    pub base: NmeaBase,
+    /// UTC time of position fix
+    pub time: NmeaTime,
+    /// Date of position fix
+    pub date: NmeaDate,
+    /// Status (true = valid, false = invalid)
+    pub status: bool,
+    /// Latitude position
+    pub latitude: Position,
+    /// Longitude position
+    pub longitude: Position,
+    /// Speed over ground in knots
+    pub speed_knots: f32,
+    /// Track angle in degrees (true north)
+    pub track_degrees: f32,
+    /// Magnetic variation in degrees
+    pub magnetic_variation: f32,
+    /// Direction of magnetic variation (E/W)
+    pub magnetic_variation_direction: CardinalDirection,
+}
+
+impl Default for Gprmc {
+    fn default() -> Self {
+        Self {
+            base: NmeaBase {
+                sentence_type: NmeaType::Gprmc,
+                errors: 0,
+            },
+            time: NmeaTime::default(),
+            date: NmeaDate::default(),
+            status: false,
+            latitude: Position::default(),
+            longitude: Position::default(),
+            speed_knots: 0.0,
+            track_degrees: 0.0,
+            magnetic_variation: 0.0,
+            magnetic_variation_direction: CardinalDirection::Unknown,
+        }
+    }
+}
+
+/// GPGLL sentence - Geographic Position - Latitude/Longitude
+#[derive(Debug, Clone, PartialEq)]
+pub struct Gpgll {
+    /// Base sentence information
+    pub base: NmeaBase,
+    /// Latitude position
+    pub latitude: Position,
+    /// Longitude position
+    pub longitude: Position,
+    /// UTC time of position fix
+    pub time: NmeaTime,
+    /// Status (true = valid, false = invalid)
+    pub status: bool,
+}
+
+impl Default for Gpgll {
+    fn default() -> Self {
+        Self {
+            base: NmeaBase {
+                sentence_type: NmeaType::Gpgll,
+                errors: 0,
+            },
+            latitude: Position::default(),
+            longitude: Position::default(),
+            time: NmeaTime::default(),
+            status: false,
+        }
+    }
+}
+
+/// Parsed NMEA sentence
+#[derive(Debug, Clone, PartialEq)]
+pub enum NmeaSentence {
+    /// GPGGA sentence
+    Gpgga(Gpgga),
+    /// GPRMC sentence
+    Gprmc(Gprmc),
+    /// GPGLL sentence
+    Gpgll(Gpgll),
+    /// Unknown or unsupported sentence
+    Unknown,
+}
+
+impl NmeaSentence {
+    /// Get the sentence type
+    pub fn sentence_type(&self) -> NmeaType {
+        match self {
+            NmeaSentence::Gpgga(_) => NmeaType::Gpgga,
+            NmeaSentence::Gprmc(_) => NmeaType::Gprmc,
+            NmeaSentence::Gpgll(_) => NmeaType::Gpgll,
+            NmeaSentence::Unknown => NmeaType::Unknown,
+        }
+    }
+
+    /// Get the number of parsing errors
+    pub fn errors(&self) -> u32 {
+        match self {
+            NmeaSentence::Gpgga(s) => s.base.errors,
+            NmeaSentence::Gprmc(s) => s.base.errors,
+            NmeaSentence::Gpgll(s) => s.base.errors,
+            NmeaSentence::Unknown => 0,
+        }
+    }
+}
+
+/// NMEA parsing errors
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NmeaError {
+    /// Sentence length is invalid (too short or too long)
+    InvalidLength,
+    /// Sentence doesn't start with '$'
+    InvalidStart,
+    /// Sentence doesn't end with '\r\n'
+    InvalidEnd,
+    /// Invalid sentence prefix (not 5 uppercase letters followed by comma)
+    InvalidPrefix,
+    /// Checksum validation failed
+    InvalidChecksum,
+    /// Error parsing field data
+    ParseError,
+    /// Sentence type is not supported
+    UnsupportedSentence,
+}
+
+/// NMEA parser utilities
+#[derive(Debug)]
+pub struct NmeaParser;
+
+impl NmeaParser {
+    /// Get sentence type from NMEA string
+    pub fn get_sentence_type(sentence: &str) -> NmeaType {
+        if sentence.len() < 6 {
+            return NmeaType::Unknown;
+        }
+
+        let prefix = &sentence[1..6];
+        match prefix {
+            "GPGGA" | "GNGGA" => NmeaType::Gpgga,
+            "GPRMC" | "GNRMC" => NmeaType::Gprmc,
+            "GPGLL" | "GNGLL" => NmeaType::Gpgll,
+            "GPGSA" | "GNGSA" => NmeaType::Gpgsa,
+            "GPGSV" | "GNGSV" => NmeaType::Gpgsv,
+            "GPTXT" | "GNTXT" => NmeaType::Gptxt,
+            "GPVTG" | "GNVTG" => NmeaType::Gpvtg,
+            _ => NmeaType::Unknown,
+        }
+    }
+
+    /// Calculate NMEA checksum
+    pub fn calculate_checksum(sentence: &str) -> u8 {
+        let bytes = sentence.as_bytes();
+        let mut checksum = 0u8;
+
+        // Start after '$' and stop at '*' or end
+        let start = if bytes[0] == b'$' { 1 } else { 0 };
+
+        for &byte in &bytes[start..] {
+            if byte == b'*' || byte == NMEA_END_CHAR_1 {
+                break;
+            }
+            checksum ^= byte;
+        }
+
+        checksum
+    }
+
+    /// Check if sentence has a checksum
+    pub fn has_checksum(sentence: &str) -> bool {
+        sentence.len() >= 5 && sentence.chars().nth(sentence.len() - 5) == Some('*')
+    }
+
+    /// Validate NMEA sentence
+    pub fn validate(sentence: &str, check_checksum: bool) -> Result<(), NmeaError> {
+        let len = sentence.len();
+
+        // Check length
+        if len < 9 {
+            return Err(NmeaError::InvalidLength);
+        }
+        if len > NMEA_MAX_LENGTH {
+            return Err(NmeaError::InvalidLength);
+        }
+
+        let bytes = sentence.as_bytes();
+
+        // Check start character
+        if bytes[0] != b'$' {
+            return Err(NmeaError::InvalidStart);
+        }
+
+        // Check end characters
+        if len >= 2 && (bytes[len - 2] != NMEA_END_CHAR_1 || bytes[len - 1] != NMEA_END_CHAR_2) {
+            return Err(NmeaError::InvalidEnd);
+        }
+
+        // Check prefix (5 uppercase letters)
+        for i in 1..6 {
+            if i >= len {
+                return Err(NmeaError::InvalidPrefix);
+            }
+            let c = bytes[i];
+            if !(c >= b'A' && c <= b'Z') {
+                return Err(NmeaError::InvalidPrefix);
+            }
+        }
+
+        // Check comma after prefix
+        if len <= 6 || bytes[6] != b',' {
+            return Err(NmeaError::InvalidPrefix);
+        }
+
+        // Check checksum if requested and present
+        if check_checksum && Self::has_checksum(sentence) {
+            let expected_checksum = Self::calculate_checksum(sentence);
+            let checksum_str = &sentence[len - 4..len - 2];
+            if let Ok(actual_checksum) = u8::from_str_radix(checksum_str, 16) {
+                if expected_checksum != actual_checksum {
+                    return Err(NmeaError::InvalidChecksum);
+                }
+            } else {
+                return Err(NmeaError::InvalidChecksum);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Parse position from NMEA format (e.g., "4916.45")
+    pub fn parse_position(value: &str) -> Result<(i32, f64), NmeaError> {
+        if value.is_empty() {
+            return Err(NmeaError::ParseError);
+        }
+
+        // Find decimal point
+        if let Some(dot_pos) = value.find('.') {
+            if dot_pos < 2 {
+                return Err(NmeaError::ParseError);
+            }
+
+            // Minutes start 2 digits before the decimal point
+            let minutes_start = dot_pos - 2;
+            let degrees_str = &value[..minutes_start];
+            let minutes_str = &value[minutes_start..];
+
+            let degrees = degrees_str
+                .parse::<i32>()
+                .map_err(|_| NmeaError::ParseError)?;
+            let minutes = minutes_str
+                .parse::<f64>()
+                .map_err(|_| NmeaError::ParseError)?;
+
+            Ok((degrees, minutes))
+        } else {
+            Err(NmeaError::ParseError)
+        }
+    }
+
+    /// Parse time from NMEA format (e.g., "225444" or "225444.123")
+    pub fn parse_time(value: &str) -> Result<NmeaTime, NmeaError> {
+        if value.is_empty() {
+            return Err(NmeaError::ParseError);
+        }
+
+        // Handle fractional seconds by ignoring them
+        let time_str = if let Some(dot_pos) = value.find('.') {
+            &value[..dot_pos]
+        } else {
+            value
+        };
+
+        if time_str.len() < 6 {
+            return Err(NmeaError::ParseError);
+        }
+
+        let time_num = time_str.parse::<u32>().map_err(|_| NmeaError::ParseError)?;
+
+        let hour = (time_num / 10000) as u8;
+        let minute = ((time_num % 10000) / 100) as u8;
+        let second = (time_num % 100) as u8;
+
+        if hour > 23 || minute > 59 || second > 59 {
+            return Err(NmeaError::ParseError);
+        }
+
+        Ok(NmeaTime {
+            hour,
+            minute,
+            second,
+        })
+    }
+
+    /// Parse date from NMEA format (e.g., "230394" for 23/03/1994)
+    pub fn parse_date(value: &str) -> Result<NmeaDate, NmeaError> {
+        if value.is_empty() || value.len() != 6 {
+            return Err(NmeaError::ParseError);
+        }
+
+        let date_num = value.parse::<u32>().map_err(|_| NmeaError::ParseError)?;
+
+        let day = (date_num / 10000) as u8;
+        let month = ((date_num % 10000) / 100) as u8;
+        let year_short = (date_num % 100) as u16;
+
+        // Convert 2-digit year to 4-digit year (assuming 2000-2099)
+        let year = if year_short >= 80 {
+            1900 + year_short
+        } else {
+            2000 + year_short
+        };
+
+        if day == 0 || day > 31 || month == 0 || month > 12 {
+            return Err(NmeaError::ParseError);
+        }
+
+        Ok(NmeaDate { day, month, year })
+    }
+
+    /// Split sentence into fields by comma
+    pub fn split_fields(sentence: &str) -> Result<heapless::Vec<&str, 32>, NmeaError> {
+        // Remove sentence type and checksum
+        let start = sentence.find(',').ok_or(NmeaError::ParseError)? + 1;
+        let end = if Self::has_checksum(sentence) {
+            sentence.len() - 5 // Remove "*XX\r\n"
+        } else {
+            sentence.len() - 2 // Remove "\r\n"
+        };
+
+        if start >= end {
+            return Ok(heapless::Vec::new());
+        }
+
+        let data_part = &sentence[start..end];
+        let mut fields = heapless::Vec::new();
+
+        for field in data_part.split(',') {
+            fields.push(field).map_err(|_| NmeaError::ParseError)?;
+        }
+
+        Ok(fields)
+    }
+
+    /// Parse NMEA sentence
+    pub fn parse(sentence: &str, check_checksum: bool) -> Result<NmeaSentence, NmeaError> {
+        // Validate sentence
+        Self::validate(sentence, check_checksum)?;
+
+        // Get sentence type
+        let sentence_type = Self::get_sentence_type(sentence);
+
+        // Split into fields
+        let fields = Self::split_fields(sentence)?;
+
+        // Parse based on type
+        match sentence_type {
+            NmeaType::Gpgga => Ok(NmeaSentence::Gpgga(Self::parse_gpgga(&fields)?)),
+            NmeaType::Gprmc => Ok(NmeaSentence::Gprmc(Self::parse_gprmc(&fields)?)),
+            NmeaType::Gpgll => Ok(NmeaSentence::Gpgll(Self::parse_gpgll(&fields)?)),
+            _ => Err(NmeaError::UnsupportedSentence),
+        }
+    }
+
+    /// Parse GPGGA sentence
+    fn parse_gpgga(fields: &[&str]) -> Result<Gpgga, NmeaError> {
+        let mut gpgga = Gpgga::default();
+        let mut errors = 0u32;
+
+        // Parse each field
+        for (i, &field) in fields.iter().enumerate() {
+            if field.is_empty() {
+                continue;
+            }
+
+            match i {
+                0 => {
+                    // Time
+                    match Self::parse_time(field) {
+                        Ok(time) => gpgga.time = time,
+                        Err(_) => errors += 1,
+                    }
+                }
+                1 => {
+                    // Latitude
+                    match Self::parse_position(field) {
+                        Ok((degrees, minutes)) => {
+                            gpgga.latitude.degrees = degrees;
+                            gpgga.latitude.minutes = minutes;
+                        }
+                        Err(_) => errors += 1,
+                    }
+                }
+                2 => {
+                    // Latitude direction
+                    gpgga.latitude.cardinal =
+                        CardinalDirection::from_char(field.chars().next().unwrap_or('\0'));
+                }
+                3 => {
+                    // Longitude
+                    match Self::parse_position(field) {
+                        Ok((degrees, minutes)) => {
+                            gpgga.longitude.degrees = degrees;
+                            gpgga.longitude.minutes = minutes;
+                        }
+                        Err(_) => errors += 1,
+                    }
+                }
+                4 => {
+                    // Longitude direction
+                    gpgga.longitude.cardinal =
+                        CardinalDirection::from_char(field.chars().next().unwrap_or('\0'));
+                }
+                5 => {
+                    // Position fix indicator
+                    gpgga.position_fix = field.parse().unwrap_or(0);
+                }
+                6 => {
+                    // Number of satellites
+                    gpgga.satellites_used = field.parse().unwrap_or(0);
+                }
+                7 => {
+                    // HDOP
+                    gpgga.hdop = field.parse().unwrap_or(0.0);
+                }
+                8 => {
+                    // Altitude
+                    gpgga.altitude = field.parse().unwrap_or(0.0);
+                }
+                9 => {
+                    // Altitude unit
+                    gpgga.altitude_unit = field.chars().next().unwrap_or('M');
+                }
+                10 => {
+                    // Undulation
+                    gpgga.undulation = field.parse().unwrap_or(-9999.999);
+                }
+                11 => {
+                    // Undulation unit
+                    gpgga.undulation_unit = field.chars().next().unwrap_or('M');
+                }
+                12 => {
+                    // DGPS age
+                    if let Ok(age) = field.parse::<f32>() {
+                        gpgga.dgps_age = Some(age);
+                    }
+                }
+                13 => {
+                    // DGPS station ID
+                    if let Ok(id) = field.parse::<u16>() {
+                        gpgga.dgps_station_id = Some(id);
+                    }
+                }
+                _ => {} // Ignore extra fields
+            }
+        }
+
+        gpgga.base.errors = errors;
+        Ok(gpgga)
+    }
+
+    /// Parse GPRMC sentence
+    fn parse_gprmc(fields: &[&str]) -> Result<Gprmc, NmeaError> {
+        let mut gprmc = Gprmc::default();
+        let mut errors = 0u32;
+
+        for (i, &field) in fields.iter().enumerate() {
+            if field.is_empty() {
+                continue;
+            }
+
+            match i {
+                0 => {
+                    // Time
+                    match Self::parse_time(field) {
+                        Ok(time) => gprmc.time = time,
+                        Err(_) => errors += 1,
+                    }
+                }
+                1 => {
+                    // Status
+                    gprmc.status = field == "A";
+                }
+                2 => {
+                    // Latitude
+                    match Self::parse_position(field) {
+                        Ok((degrees, minutes)) => {
+                            gprmc.latitude.degrees = degrees;
+                            gprmc.latitude.minutes = minutes;
+                        }
+                        Err(_) => errors += 1,
+                    }
+                }
+                3 => {
+                    // Latitude direction
+                    gprmc.latitude.cardinal =
+                        CardinalDirection::from_char(field.chars().next().unwrap_or('\0'));
+                }
+                4 => {
+                    // Longitude
+                    match Self::parse_position(field) {
+                        Ok((degrees, minutes)) => {
+                            gprmc.longitude.degrees = degrees;
+                            gprmc.longitude.minutes = minutes;
+                        }
+                        Err(_) => errors += 1,
+                    }
+                }
+                5 => {
+                    // Longitude direction
+                    gprmc.longitude.cardinal =
+                        CardinalDirection::from_char(field.chars().next().unwrap_or('\0'));
+                }
+                6 => {
+                    // Speed in knots
+                    gprmc.speed_knots = field.parse().unwrap_or(0.0);
+                }
+                7 => {
+                    // Track in degrees
+                    gprmc.track_degrees = field.parse().unwrap_or(0.0);
+                }
+                8 => {
+                    // Date
+                    match Self::parse_date(field) {
+                        Ok(date) => gprmc.date = date,
+                        Err(_) => errors += 1,
+                    }
+                }
+                9 => {
+                    // Magnetic variation
+                    gprmc.magnetic_variation = field.parse().unwrap_or(0.0);
+                }
+                10 => {
+                    // Magnetic variation direction
+                    gprmc.magnetic_variation_direction =
+                        CardinalDirection::from_char(field.chars().next().unwrap_or('\0'));
+                }
+                _ => {} // Ignore extra fields
+            }
+        }
+
+        gprmc.base.errors = errors;
+        Ok(gprmc)
+    }
+
+    /// Parse GPGLL sentence
+    fn parse_gpgll(fields: &[&str]) -> Result<Gpgll, NmeaError> {
+        let mut gpgll = Gpgll::default();
+        let mut errors = 0u32;
+
+        for (i, &field) in fields.iter().enumerate() {
+            if field.is_empty() {
+                continue;
+            }
+
+            match i {
+                0 => {
+                    // Latitude
+                    match Self::parse_position(field) {
+                        Ok((degrees, minutes)) => {
+                            gpgll.latitude.degrees = degrees;
+                            gpgll.latitude.minutes = minutes;
+                        }
+                        Err(_) => errors += 1,
+                    }
+                }
+                1 => {
+                    // Latitude direction
+                    gpgll.latitude.cardinal =
+                        CardinalDirection::from_char(field.chars().next().unwrap_or('\0'));
+                }
+                2 => {
+                    // Longitude
+                    match Self::parse_position(field) {
+                        Ok((degrees, minutes)) => {
+                            gpgll.longitude.degrees = degrees;
+                            gpgll.longitude.minutes = minutes;
+                        }
+                        Err(_) => errors += 1,
+                    }
+                }
+                3 => {
+                    // Longitude direction
+                    gpgll.longitude.cardinal =
+                        CardinalDirection::from_char(field.chars().next().unwrap_or('\0'));
+                }
+                4 => {
+                    // Time
+                    match Self::parse_time(field) {
+                        Ok(time) => gpgll.time = time,
+                        Err(_) => errors += 1,
+                    }
+                }
+                5 => {
+                    // Status
+                    gpgll.status = field == "A";
+                }
+                _ => {} // Ignore extra fields
+            }
+        }
+
+        gpgll.base.errors = errors;
+        Ok(gpgll)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,3 +135,5 @@ pub mod system;
 
 /// Over-the-air (OTA) update logic combining network and storage layers.
 pub mod ota;
+
+pub mod gps;

--- a/tests/gps/mod.rs
+++ b/tests/gps/mod.rs
@@ -1,0 +1,448 @@
+//! GPS NMEA parser tests
+
+use libiot::gps::*;
+
+#[test]
+fn test_cardinal_direction_parsing() {
+    assert_eq!(CardinalDirection::from_char('N'), CardinalDirection::North);
+    assert_eq!(CardinalDirection::from_char('E'), CardinalDirection::East);
+    assert_eq!(CardinalDirection::from_char('S'), CardinalDirection::South);
+    assert_eq!(CardinalDirection::from_char('W'), CardinalDirection::West);
+    assert_eq!(
+        CardinalDirection::from_char('X'),
+        CardinalDirection::Unknown
+    );
+
+    assert_eq!(CardinalDirection::North.to_char(), 'N');
+    assert_eq!(CardinalDirection::East.to_char(), 'E');
+    assert_eq!(CardinalDirection::South.to_char(), 'S');
+    assert_eq!(CardinalDirection::West.to_char(), 'W');
+    assert_eq!(CardinalDirection::Unknown.to_char(), '\0');
+}
+
+#[test]
+fn test_position_decimal_conversion() {
+    let pos_north = Position::new(48, 7.038, CardinalDirection::North);
+    assert!((pos_north.to_decimal_degrees() - 48.11730).abs() < 0.0001);
+
+    let pos_south = Position::new(48, 7.038, CardinalDirection::South);
+    assert!((pos_south.to_decimal_degrees() + 48.11730).abs() < 0.0001);
+
+    let pos_east = Position::new(11, 31.000, CardinalDirection::East);
+    assert!((pos_east.to_decimal_degrees() - 11.51667).abs() < 0.0001);
+
+    let pos_west = Position::new(11, 31.000, CardinalDirection::West);
+    assert!((pos_west.to_decimal_degrees() + 11.51667).abs() < 0.0001);
+}
+
+#[test]
+fn test_sentence_type_detection() {
+    assert_eq!(
+        NmeaParser::get_sentence_type("$GPGGA,test"),
+        NmeaType::Gpgga
+    );
+    assert_eq!(
+        NmeaParser::get_sentence_type("$GNGGA,test"),
+        NmeaType::Gpgga
+    );
+    assert_eq!(
+        NmeaParser::get_sentence_type("$GPRMC,test"),
+        NmeaType::Gprmc
+    );
+    assert_eq!(
+        NmeaParser::get_sentence_type("$GNRMC,test"),
+        NmeaType::Gprmc
+    );
+    assert_eq!(
+        NmeaParser::get_sentence_type("$GPGLL,test"),
+        NmeaType::Gpgll
+    );
+    assert_eq!(
+        NmeaParser::get_sentence_type("$GNGLL,test"),
+        NmeaType::Gpgll
+    );
+    assert_eq!(
+        NmeaParser::get_sentence_type("$GPXXX,test"),
+        NmeaType::Unknown
+    );
+    assert_eq!(NmeaParser::get_sentence_type("$GP"), NmeaType::Unknown);
+}
+
+#[test]
+fn test_checksum_calculation() {
+    // Test case from libnmea C library
+    let sentence1 = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47";
+    assert_eq!(NmeaParser::calculate_checksum(sentence1), 0x47);
+
+    // Test case from NMEA standard
+    let sentence2 = "$GPRMC,225446,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E*68";
+    assert_eq!(NmeaParser::calculate_checksum(sentence2), 0x68);
+
+    // Test without checksum
+    let sentence3 = "$GPGLL,4916.45,N,12311.12,W,225444,A";
+    assert_eq!(NmeaParser::calculate_checksum(sentence3), 0x1D);
+}
+
+#[test]
+fn test_checksum_detection() {
+    assert!(NmeaParser::has_checksum("$GPGGA,test*47\r\n"));
+    assert!(NmeaParser::has_checksum("$GPRMC,test*68\r\n"));
+    assert!(!NmeaParser::has_checksum("$GPGLL,test\r\n"));
+    assert!(!NmeaParser::has_checksum("$GP*\r\n")); // Too short
+}
+
+#[test]
+fn test_sentence_validation() {
+    // Valid sentences
+    let valid1 = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n";
+    assert!(NmeaParser::validate(valid1, true).is_ok());
+
+    let valid2 = "$GPRMC,225446,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E\r\n";
+    assert!(NmeaParser::validate(valid2, false).is_ok());
+
+    // Invalid sentences
+    assert_eq!(
+        NmeaParser::validate("GPGGA,test\r\n", false),
+        Err(NmeaError::InvalidStart)
+    );
+    assert_eq!(
+        NmeaParser::validate("$GPGGA,test", false),
+        Err(NmeaError::InvalidEnd)
+    );
+    assert_eq!(
+        NmeaParser::validate("$gpgga,test\r\n", false),
+        Err(NmeaError::InvalidPrefix)
+    );
+    assert_eq!(
+        NmeaParser::validate("$GPGGA test\r\n", false),
+        Err(NmeaError::InvalidPrefix)
+    );
+    assert_eq!(
+        NmeaParser::validate("$GP\r\n", false),
+        Err(NmeaError::InvalidLength)
+    );
+
+    // Invalid checksum
+    let invalid_checksum = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*46\r\n";
+    assert_eq!(
+        NmeaParser::validate(invalid_checksum, true),
+        Err(NmeaError::InvalidChecksum)
+    );
+}
+
+#[test]
+fn test_position_parsing() {
+    // Test valid positions
+    let (degrees, minutes) = NmeaParser::parse_position("4807.038").unwrap();
+    assert_eq!(degrees, 48);
+    assert!((minutes - 7.038).abs() < 0.001);
+
+    let (degrees, minutes) = NmeaParser::parse_position("12311.12").unwrap();
+    assert_eq!(degrees, 123);
+    assert!((minutes - 11.12).abs() < 0.001);
+
+    let (degrees, minutes) = NmeaParser::parse_position("0000.000").unwrap();
+    assert_eq!(degrees, 0);
+    assert!((minutes - 0.0).abs() < 0.001);
+
+    // Test invalid positions
+    assert!(NmeaParser::parse_position("").is_err());
+    assert!(NmeaParser::parse_position("48").is_err());
+    assert!(NmeaParser::parse_position("4807").is_err());
+    assert!(NmeaParser::parse_position("abc.def").is_err());
+}
+
+#[test]
+fn test_time_parsing() {
+    // Test valid times
+    let time = NmeaParser::parse_time("123519").unwrap();
+    assert_eq!(time.hour, 12);
+    assert_eq!(time.minute, 35);
+    assert_eq!(time.second, 19);
+
+    let time = NmeaParser::parse_time("000000").unwrap();
+    assert_eq!(time.hour, 0);
+    assert_eq!(time.minute, 0);
+    assert_eq!(time.second, 0);
+
+    let time = NmeaParser::parse_time("235959").unwrap();
+    assert_eq!(time.hour, 23);
+    assert_eq!(time.minute, 59);
+    assert_eq!(time.second, 59);
+
+    // Test time with fractional seconds (should be ignored)
+    let time = NmeaParser::parse_time("123519.123").unwrap();
+    assert_eq!(time.hour, 12);
+    assert_eq!(time.minute, 35);
+    assert_eq!(time.second, 19);
+
+    // Test invalid times
+    assert!(NmeaParser::parse_time("").is_err());
+    assert!(NmeaParser::parse_time("12345").is_err());
+    assert!(NmeaParser::parse_time("246000").is_err()); // Invalid hour
+    assert!(NmeaParser::parse_time("126000").is_err()); // Invalid minute
+    assert!(NmeaParser::parse_time("123560").is_err()); // Invalid second
+    assert!(NmeaParser::parse_time("abcdef").is_err());
+}
+
+#[test]
+fn test_date_parsing() {
+    // Test valid dates
+    let date = NmeaParser::parse_date("230394").unwrap();
+    assert_eq!(date.day, 23);
+    assert_eq!(date.month, 3);
+    assert_eq!(date.year, 1994);
+
+    let date = NmeaParser::parse_date("010100").unwrap();
+    assert_eq!(date.day, 1);
+    assert_eq!(date.month, 1);
+    assert_eq!(date.year, 2000);
+
+    let date = NmeaParser::parse_date("311299").unwrap();
+    assert_eq!(date.day, 31);
+    assert_eq!(date.month, 12);
+    assert_eq!(date.year, 1999);
+
+    // Test invalid dates
+    assert!(NmeaParser::parse_date("").is_err());
+    assert!(NmeaParser::parse_date("23039").is_err()); // Too short
+    assert!(NmeaParser::parse_date("2303944").is_err()); // Too long
+    assert!(NmeaParser::parse_date("000394").is_err()); // Invalid day
+    assert!(NmeaParser::parse_date("230094").is_err()); // Invalid month
+    assert!(NmeaParser::parse_date("320394").is_err()); // Invalid day
+    assert!(NmeaParser::parse_date("231394").is_err()); // Invalid month
+    assert!(NmeaParser::parse_date("abcdef").is_err());
+}
+
+#[test]
+fn test_field_splitting() {
+    let sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n";
+    let fields = NmeaParser::split_fields(sentence).unwrap();
+
+    assert_eq!(fields.len(), 14);
+    assert_eq!(fields[0], "123519");
+    assert_eq!(fields[1], "4807.038");
+    assert_eq!(fields[2], "N");
+    assert_eq!(fields[3], "01131.000");
+    assert_eq!(fields[4], "E");
+    assert_eq!(fields[5], "1");
+    assert_eq!(fields[6], "08");
+    assert_eq!(fields[7], "0.9");
+    assert_eq!(fields[8], "545.4");
+    assert_eq!(fields[9], "M");
+    assert_eq!(fields[10], "46.9");
+    assert_eq!(fields[11], "M");
+    assert_eq!(fields[12], "");
+    assert_eq!(fields[13], "");
+}
+
+#[test]
+fn test_gpgga_parsing() {
+    let sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n";
+    let parsed = NmeaParser::parse(sentence, true).unwrap();
+
+    if let NmeaSentence::Gpgga(gpgga) = parsed {
+        assert_eq!(gpgga.base.sentence_type, NmeaType::Gpgga);
+        assert_eq!(gpgga.base.errors, 0);
+
+        assert_eq!(gpgga.time.hour, 12);
+        assert_eq!(gpgga.time.minute, 35);
+        assert_eq!(gpgga.time.second, 19);
+
+        assert_eq!(gpgga.latitude.degrees, 48);
+        assert!((gpgga.latitude.minutes - 7.038).abs() < 0.001);
+        assert_eq!(gpgga.latitude.cardinal, CardinalDirection::North);
+
+        assert_eq!(gpgga.longitude.degrees, 11);
+        assert!((gpgga.longitude.minutes - 31.000).abs() < 0.001);
+        assert_eq!(gpgga.longitude.cardinal, CardinalDirection::East);
+
+        assert_eq!(gpgga.position_fix, 1);
+        assert_eq!(gpgga.satellites_used, 8);
+        assert!((gpgga.hdop - 0.9).abs() < 0.001);
+        assert!((gpgga.altitude - 545.4).abs() < 0.001);
+        assert_eq!(gpgga.altitude_unit, 'M');
+        assert!((gpgga.undulation - 46.9).abs() < 0.001);
+        assert_eq!(gpgga.undulation_unit, 'M');
+    } else {
+        panic!("Expected GPGGA sentence");
+    }
+}
+
+#[test]
+fn test_gprmc_parsing() {
+    let sentence = "$GPRMC,225446,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E*68\r\n";
+    let parsed = NmeaParser::parse(sentence, true).unwrap();
+
+    if let NmeaSentence::Gprmc(gprmc) = parsed {
+        assert_eq!(gprmc.base.sentence_type, NmeaType::Gprmc);
+        assert_eq!(gprmc.base.errors, 0);
+
+        assert_eq!(gprmc.time.hour, 22);
+        assert_eq!(gprmc.time.minute, 54);
+        assert_eq!(gprmc.time.second, 46);
+
+        assert_eq!(gprmc.status, true);
+
+        assert_eq!(gprmc.latitude.degrees, 49);
+        assert!((gprmc.latitude.minutes - 16.45).abs() < 0.001);
+        assert_eq!(gprmc.latitude.cardinal, CardinalDirection::North);
+
+        assert_eq!(gprmc.longitude.degrees, 123);
+        assert!((gprmc.longitude.minutes - 11.12).abs() < 0.001);
+        assert_eq!(gprmc.longitude.cardinal, CardinalDirection::West);
+
+        assert!((gprmc.speed_knots - 0.5).abs() < 0.001);
+        assert!((gprmc.track_degrees - 54.7).abs() < 0.001);
+
+        assert_eq!(gprmc.date.day, 19);
+        assert_eq!(gprmc.date.month, 11);
+        assert_eq!(gprmc.date.year, 1994);
+
+        assert!((gprmc.magnetic_variation - 20.3).abs() < 0.001);
+        assert_eq!(gprmc.magnetic_variation_direction, CardinalDirection::East);
+    } else {
+        panic!("Expected GPRMC sentence");
+    }
+}
+
+#[test]
+fn test_gpgll_parsing() {
+    let sentence = "$GPGLL,4916.45,N,12311.12,W,225444,A*1D\r\n";
+    let parsed = NmeaParser::parse(sentence, true).unwrap();
+
+    if let NmeaSentence::Gpgll(gpgll) = parsed {
+        assert_eq!(gpgll.base.sentence_type, NmeaType::Gpgll);
+        assert_eq!(gpgll.base.errors, 0);
+
+        assert_eq!(gpgll.latitude.degrees, 49);
+        assert!((gpgll.latitude.minutes - 16.45).abs() < 0.001);
+        assert_eq!(gpgll.latitude.cardinal, CardinalDirection::North);
+
+        assert_eq!(gpgll.longitude.degrees, 123);
+        assert!((gpgll.longitude.minutes - 11.12).abs() < 0.001);
+        assert_eq!(gpgll.longitude.cardinal, CardinalDirection::West);
+
+        assert_eq!(gpgll.time.hour, 22);
+        assert_eq!(gpgll.time.minute, 54);
+        assert_eq!(gpgll.time.second, 44);
+
+        assert_eq!(gpgll.status, true);
+    } else {
+        panic!("Expected GPGLL sentence");
+    }
+}
+
+#[test]
+fn test_invalid_sentence_parsing() {
+    // Test unsupported sentence type
+    let sentence = "$GPXXX,test,data\r\n";
+    assert_eq!(
+        NmeaParser::parse(sentence, false),
+        Err(NmeaError::UnsupportedSentence)
+    );
+
+    // Test invalid sentence format
+    let sentence = "GPGGA,test,data\r\n";
+    assert_eq!(
+        NmeaParser::parse(sentence, false),
+        Err(NmeaError::InvalidStart)
+    );
+}
+
+#[test]
+fn test_sentence_with_empty_fields() {
+    // GPGGA with some empty fields
+    let sentence = "$GPGGA,123519,,N,,E,1,08,0.9,545.4,M,46.9,M,,*2C\r\n";
+    let parsed = NmeaParser::parse(sentence, true).unwrap();
+
+    if let NmeaSentence::Gpgga(gpgga) = parsed {
+        assert_eq!(gpgga.base.sentence_type, NmeaType::Gpgga);
+        // Should have some errors due to empty position fields
+        assert!(gpgga.base.errors > 0);
+
+        assert_eq!(gpgga.time.hour, 12);
+        assert_eq!(gpgga.time.minute, 35);
+        assert_eq!(gpgga.time.second, 19);
+
+        // Position fields should be default due to parsing errors
+        assert_eq!(gpgga.latitude.degrees, 0);
+        assert_eq!(gpgga.longitude.degrees, 0);
+
+        assert_eq!(gpgga.position_fix, 1);
+        assert_eq!(gpgga.satellites_used, 8);
+    } else {
+        panic!("Expected GPGGA sentence");
+    }
+}
+
+#[test]
+fn test_sentence_methods() {
+    let sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n";
+    let parsed = NmeaParser::parse(sentence, true).unwrap();
+
+    assert_eq!(parsed.sentence_type(), NmeaType::Gpgga);
+    assert_eq!(parsed.errors(), 0);
+
+    let unknown = NmeaSentence::Unknown;
+    assert_eq!(unknown.sentence_type(), NmeaType::Unknown);
+    assert_eq!(unknown.errors(), 0);
+}
+
+#[test]
+fn test_real_nmea_sentences() {
+    // Real NMEA sentences from GPS devices
+    let sentences = [
+        "$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76\r\n",
+        "$GPRMC,092750.000,A,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A*43\r\n",
+        "$GPGLL,5321.6802,N,00630.3372,W,092750.000,A,A*7C\r\n",
+        "$GNGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*5E\r\n",
+        "$GNRMC,225446,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E*50\r\n",
+    ];
+
+    for sentence in &sentences {
+        let result = NmeaParser::parse(sentence, true);
+        assert!(result.is_ok(), "Failed to parse: {}", sentence);
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.errors(), 0, "Parse errors in: {}", sentence);
+    }
+}
+
+#[test]
+fn test_gnss_sentences() {
+    // Test GNSS (multi-constellation) sentences
+    let gngga = "$GNGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*5E\r\n";
+    let parsed = NmeaParser::parse(gngga, true).unwrap();
+    assert_eq!(parsed.sentence_type(), NmeaType::Gpgga);
+
+    let gnrmc = "$GNRMC,225446,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E*50\r\n";
+    let parsed = NmeaParser::parse(gnrmc, true).unwrap();
+    assert_eq!(parsed.sentence_type(), NmeaType::Gprmc);
+
+    let gngll = "$GNGLL,4916.45,N,12311.12,W,225444,A*05\r\n";
+    let parsed = NmeaParser::parse(gngll, true).unwrap();
+    assert_eq!(parsed.sentence_type(), NmeaType::Gpgll);
+}
+
+#[test]
+fn test_edge_cases() {
+    // Test minimum valid sentence
+    let min_sentence = "$GPGGA,,,,,,,,,,,,,*56\r\n";
+    let result = NmeaParser::parse(min_sentence, true);
+    assert!(result.is_ok());
+
+    // Test sentence at maximum length
+    let long_sentence = format!("$GPGGA,{},*00\r\n", "1,".repeat(35));
+    assert!(long_sentence.len() <= NMEA_MAX_LENGTH);
+
+    // Test position at equator and prime meridian
+    let equator_sentence = "$GPGGA,123519,0000.000,N,00000.000,E,1,08,0.9,0.0,M,0.0,M,,*6B\r\n";
+    let parsed = NmeaParser::parse(equator_sentence, true).unwrap();
+    if let NmeaSentence::Gpgga(gpgga) = parsed {
+        assert_eq!(gpgga.latitude.degrees, 0);
+        assert_eq!(gpgga.longitude.degrees, 0);
+        assert!((gpgga.latitude.minutes - 0.0).abs() < 0.001);
+        assert!((gpgga.longitude.minutes - 0.0).abs() < 0.001);
+    }
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod gps;
 pub mod network;
 pub mod ota;
 pub mod storage;


### PR DESCRIPTION
Introduces a lightweight NMEA 0183 parser in src/gps/mod.rs supporting GPGGA, GPRMC, and GPGLL sentence types, with robust validation, parsing utilities, and error handling. Adds comprehensive unit tests in tests/gps/mod.rs to verify parsing logic, edge cases, and sentence validation.